### PR TITLE
Adicionando o parse de argumentos no cli

### DIFF
--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -9,14 +9,14 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser()
 
-    commands = parser.add_subparsers(dest='command')
+    commands = parser.add_subparsers(dest="command")
     commands.required = True
 
-    init_parser = commands.add_parser('init')
+    init_parser = commands.add_parser("init")
     init_parser.set_defaults(func=init)
 
     return parser.parse_args()
 
 
-def init (args):
-    print ('Hello, World!')
+def init(args):
+    print("Hello, World!")

--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -1,2 +1,22 @@
+import argparse
+
+
 def main():
+    args = parse_args()
+    args.func(args)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    commands = parser.add_subparsers(dest='command')
+    commands.required = True
+
+    init_parser = commands.add_parser('init')
+    init_parser.set_defaults(func=init)
+
+    return parser.parse_args()
+
+
+def init (args):
     print ('Hello, World!')


### PR DESCRIPTION
O git original execulta vários sub-comandos, como `git init`, `git commit`, etc. Para isso vamos usar a biblioteca `argparse` para implementar esses sub-comandos.

O primeiro sub-comando que iremos implementar é o `init`, por enquanto ele apenas irá realizar uma print do `Hello, World!`.