### PR TITLE
3 init: Criando o diretório .ugit

### DIFF
--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -1,5 +1,7 @@
 import argparse
+import os
 
+from . import data
 
 def main():
     args = parse_args()
@@ -19,4 +21,5 @@ def parse_args():
 
 
 def init(args):
-    print("Hello, World!")
+    data.init()
+    print (f'Initialized empty ugit repository in {os.getcwd()}/{data.GIT_DIR}')

--- a/ugit/data.py
+++ b/ugit/data.py
@@ -1,0 +1,8 @@
+import os
+
+
+GIT_DIR = '.ugit'
+
+
+def init ():
+    os.makedirs (GIT_DIR)


### PR DESCRIPTION
O comando `ugit init` cria um novo repositório vazio.

O Git armazena todos os dados do repositório localmente, em um subdiretório chamado ".git", então na inicialização criaremos um.

Eu nomeei o diretório como ".ugit" ao invés de ".git" para que ele não entre em conflito com o Git, mas a ideia é a mesma.

Para implementar o init, pode se apenas chamar `os.makedirs` dentro do *cli.py*, mas a lógica será separada entre diferentes partes do código:

- *cli.py* - Encarregado de analisar e processar a entrada do usuário.
- *data.py* - Gerencia os dados no diretório .ugit. Aqui estará o código que realmente toca os arquivos no disco.

Essa separação será útil, pois o código ficará maior.