### PR TITLE
4 hash-object: Salvando Objetos

### DIFF
--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -17,9 +17,18 @@ def parse_args():
     init_parser = commands.add_parser("init")
     init_parser.set_defaults(func=init)
 
+    hash_object_parser = commands.add_parser('hash-object')
+    hash_object_parser.set_defaults(func=hash_object)
+    hash_object_parser.add_argument('file')
+
     return parser.parse_args()
 
 
 def init(args):
     data.init()
-    print (f'Initialized empty ugit repository in {os.getcwd()}/{data.GIT_DIR}')
+    print(f'Initialized empty ugit repository in {os.getcwd()}/{data.GIT_DIR}')
+
+
+def hash_object(args):
+    with open(args.file, 'rb') as f:
+        print(data.hash_object (f.read ()))

--- a/ugit/data.py
+++ b/ugit/data.py
@@ -1,8 +1,17 @@
+import hashlib
 import os
 
 
 GIT_DIR = '.ugit'
 
 
-def init ():
-    os.makedirs (GIT_DIR)
+def init():
+    os.makedirs(GIT_DIR)
+    os.makedirs(f'{GIT_DIR}/objects')
+
+
+def hash_object(data):
+    oid = hashlib.sha1 (data).hexdigest()
+    with open(f'{GIT_DIR}/objects/{oid}', 'wb') as out:
+        out.write(data)
+    return oid


### PR DESCRIPTION
Vamos criar o primeiro comando não trivial. Este comando pegará um arquivo e o armazenará em nosso diretório *.ugit* para recuperação posterior. Na linguagem do Git, esse recurso é chamado de **"banco de dados de objetos"**. Ele nos permite armazenar e recuperar *blobs* arbitrários, que são chamados de **"objetos"**. No que diz respeito ao Banco de Dados de Objetos, o conteúdo do objeto não tem nenhum significado (assim como um sistema de arquivos não se importa com a estrutura interna de um arquivo).

Como esse comando precisa do diretório *.ugit*, ele deve ser executado a partir do mesmo diretório em que você fez o `ugit init`.

Observe que este é um bloco de construção do Git de nível muito baixo e ainda não estamos falando sobre versões ou commits ou qualquer outra coisa que você possa ter ouvido falar, estamos apenas falando sobre uma interface para armazenar alguns bytes brutos.

Então, podemos armazenar um objeto, mas como nos referiríamos a ele mais tarde? Poderíamos pedir ao usuário para fornecer um nome junto com o objeto e recuperá-lo posteriormente usando o nome, mas há uma maneira melhor: podemos nos referir ao objeto usando seu **hash**.

Se você ainda não ouviu falar sobre hashes e funções de hash, sugiro que você faça uma pausa e leia um pouco sobre isso. Em resumo, uma função hash pode pegar um blob de comprimento arbitrário e produzir uma pequena "impressão digital" com um comprimento fixo. Algumas funções de hash, como SHA-1, garantem que blobs diferentes provavelmente produzirão impressões digitais diferentes (tão provável que o Git assume que é garantido). Vamos tentar algumas strings para ver um exemplo:

```sh
$ echo -n isso é legal | sha1sum
60f51187e76a9de0ff3df31f051bde04da2da891
$ echo -n isso é mais legal | sha1sum
f3c953b792f9ab39d1be0bdab7ab5f8350593004
```

Você pode ver que o hash das frases "isso é legal" e "isso é mais legal" dá hashes completamente diferentes, mesmo que a diferença entre as frases seja pequena.

Vamos usar o hash como o nome do objeto (chamaremos esse nome de "OID" - object ID).

Portanto, o fluxo do comando `hash-object` é:

- Obtenha o caminho do arquivo a ser armazenado.
- Leia o arquivo.
- Faça hash do conteúdo do arquivo usando SHA-1.
- Armazene o arquivo em `.ugit/objects/{the SHA-1 hash}`.

Esse tipo de armazenamento é chamado de **armazenamento endereçável por conteúdo** porque o "endereço" que usamos para localizar um blob é baseado no conteúdo do próprio blob. (Em contraste com o armazenamento endereçável por nome, como um sistema de arquivos típico, onde você endereça um arquivo específico por seu nome, independentemente de seu conteúdo). O armazenamento endereçável por conteúdo tem boas propriedades ao sincronizar dados entre computadores diferentes - se dois repositórios tiverem um objeto com o mesmo OID, podemos ter certeza de que são o mesmo objeto. Além disso, como é praticamente garantido que dois objetos diferentes tenham OIDs diferentes, não podemos ter conflitos de nomenclatura entre objetos.

Quando o Git real armazena objetos, ele faz algumas coisas extras, como escrever o tamanho do objeto no arquivo também, comprimi-los e dividir os objetos em 256 diretórios. Isso é feito para evitar diretórios com grande número de arquivos, o que pode prejudicar o desempenho. ***Não vamos fazer isso no ugit para simplificar***.