### PR TITLE
5 cat-file: lê os objetos em hashed

### DIFF
--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -36,7 +36,7 @@ def init(args):
 
 def hash_object(args):
     with open(args.file, 'rb') as f:
-        print(data.hash_object (f.read()))
+        print(data.hash_object(f.read()))
 
 
 def cat_file(args):

--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from . import data
 
@@ -21,6 +22,10 @@ def parse_args():
     hash_object_parser.set_defaults(func=hash_object)
     hash_object_parser.add_argument('file')
 
+    cat_file_parser = commands.add_parse('cat-file')
+    cat_file_parser.set_defaults(func=cat_file)
+    cat_file_parser.add_argument('object')
+
     return parser.parse_args()
 
 
@@ -31,4 +36,9 @@ def init(args):
 
 def hash_object(args):
     with open(args.file, 'rb') as f:
-        print(data.hash_object (f.read ()))
+        print(data.hash_object (f.read()))
+
+
+def cat_file(args):
+    sys.stdout.flush()
+    sys.stdout.buffer.write(data.get_object(args.object))

--- a/ugit/data.py
+++ b/ugit/data.py
@@ -15,3 +15,8 @@ def hash_object(data):
     with open(f'{GIT_DIR}/objects/{oid}', 'wb') as out:
         out.write(data)
     return oid
+
+
+def get_object(oid):
+    with open(f'{GIT_DIR}/objects/{oid}', 'rb') as f:
+        return f.read()


### PR DESCRIPTION
Este comando é o "oposto" de `hash-object`: ele pode imprimir um objeto pelo seu OID. Sua implementação apenas lê o arquivo em `.ugit/objects/{OID}`.

Os nomes `hash-object` e `cat-file` não são os nomes mais claros, mas são os nomes que o Git usa, então vamos mantê-los por consistência.

Agora podemos tentar o ciclo completo:

```sh
$ cd /tmp/novo
$ ugit init
Repositório ugit vazio inicializado em /tmp/new/.ugit
$ echo algum arquivo > bla
$ ugit hash-object bla
0e08b5e8c10abc3e455b75286ba4a1fbd56e18a5
$ ugit cat-file 0e08b5e8c10abc3e455b75286ba4a1fbd56e18a5
algum arquivo
```

Observe que o nome do arquivo (*bla*) não foi preservado como parte desse processo, porque, novamente, o banco de dados de objetos serve apenas para armazenar bytes para recuperação posterior e não se importa de qual nome de arquivo esses bytes vieram.