### PR TITLE
6 data: adicionar tipos a objetos

### DIFF
--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -41,4 +41,4 @@ def hash_object(args):
 
 def cat_file(args):
     sys.stdout.flush()
-    sys.stdout.buffer.write(data.get_object(args.object))
+    sys.stdout.buffer.write(data.get_object(args.object, expected=None))

--- a/ugit/data.py
+++ b/ugit/data.py
@@ -10,13 +10,21 @@ def init():
     os.makedirs(f'{GIT_DIR}/objects')
 
 
-def hash_object(data):
-    oid = hashlib.sha1 (data).hexdigest()
+def hash_object(data, type_='blob'):
+    obj = type_.encode() + b'\x00' + data
+    oid = hashlib.sha1(obj).hexdigest()
     with open(f'{GIT_DIR}/objects/{oid}', 'wb') as out:
-        out.write(data)
+        out.write(obj)
     return oid
 
 
-def get_object(oid):
+def get_object(oid, expected='blob'):
     with open(f'{GIT_DIR}/objects/{oid}', 'rb') as f:
-        return f.read()
+        obj = f.read()
+
+    type_, _, content = obj.partition(b'\x00')
+    type_ = type_.decode()
+
+    if expected is not None:
+        assert type_ == expected, f'Expected {expected}, got {type_}'
+    return content


### PR DESCRIPTION
Como veremos em breve, haverá diferentes tipos lógicos de objetos que são usados em diferentes contextos (mesmo que, do ponto de vista do Banco de Dados de Objetos, sejam apenas bytes). Para diminuir a chance de usar um objeto no contexto errado, vamos adicionar uma tag de tipo para cada objeto.

O tipo é apenas uma string que será anexada ao início do arquivo, seguida por um byte nulo. Ao ler o arquivo posteriormente, extrairemos o tipo e verificaremos se realmente é o tipo esperado.

O tipo padrão será **'blob'**, pois por padrão um objeto é uma coleção de bytes sem nenhum significado semântico adicional.

Também podemos passar `expect=None` para `get_object()` se não quisermos verificar o tipo. Isso é útil para o comando `cat-file` que é um comando debug usado para imprimir todos os objetos.