### PR TITLE
8 write-tree: List files

### DIFF
--- a/ugit/base.py
+++ b/ugit/base.py
@@ -1,1 +1,15 @@
-from . import data
+import os
+import data
+
+
+def write_tree(directory='.'):
+    with os.scandir(directory) as it:
+        for entry in it:
+            full = f'{directory}/{entry.name}'
+            if entry.is_file(follow_symlinks=False):
+                # TODO write the file to object store
+                print(full)
+            elif entry.is_dir(follow_symlinks=False):
+                write_tree(full)
+
+    # TODO actually create the tree object

--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -2,8 +2,8 @@ import argparse
 import os
 import sys
 
-from . import base
-from . import data
+import base
+import data
 
 def main():
     args = parse_args()
@@ -27,6 +27,9 @@ def parse_args():
     cat_file_parser.set_defaults(func=cat_file)
     cat_file_parser.add_argument('object')
 
+    write_tree_parser = commands.add_parser('write-tree')
+    write_tree_parser.set_defaults(func=write_tree)
+
     return parser.parse_args()
 
 
@@ -43,3 +46,6 @@ def hash_object(args):
 def cat_file(args):
     sys.stdout.flush()
     sys.stdout.buffer.write(data.get_object(args.object, expected=None))
+
+def write_tree(args):
+    base.write_tree ()


### PR DESCRIPTION
The next command is `write-tree`. This command will take the current working directory and store it to the object database. If `hash-object` was for storing an individual file, then `write-tree` is for storing a whole directory.

Like `hash-object`, `write-tree` is going to give us an OID after it's done and we'll be able to use the OID in order to retrieve the directory at a later time.

In Git's lingo a "tree" means a directory.

We'll get into the details in later changes, in this change we'll only prepare the code around the feature:

- Create a `write-tree` CLI command

- Create a `write_tree()` function in base module. Why in base module and not in data module? Because `write_tree()` is not going to write to disk directly but use the object database provided by data to store the directory. Hence it belongs to the higher-level base module.

- Add code to `write_tree()` to print a directory recursively. For now nothing is written anywhere, but we just coded the boilerplate to recursively scan a directory.

We continue in the next change.